### PR TITLE
Changing the nullability field to is_null rather than not null 

### DIFF
--- a/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
+++ b/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
@@ -61,7 +61,10 @@ class RedshiftExtract:
             t.schemaname    -- 0
             ,t.tablename    -- 1
             ,t.column       -- 2
-            ,t.notnull      -- 3
+            ,case when t.notnull then 'false' 
+              when not t.notnull then 'true' 
+              else null 
+              end         AS is_null     -- 3
             ,t.type         -- 4
             ,t.distkey      -- 5
             ,t.sortkey      -- 6

--- a/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
+++ b/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
@@ -61,10 +61,7 @@ class RedshiftExtract:
             t.schemaname    -- 0
             ,t.tablename    -- 1
             ,t.column       -- 2
-            ,CASE WHEN t.notnull THEN false 
-              WHEN NOT t.notnull THEN true 
-              ELSE null 
-              END           -- 3
+            , NOT t.notnull -- 3
             ,t.type         -- 4
             ,t.distkey      -- 5
             ,t.sortkey      -- 6

--- a/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
+++ b/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
@@ -61,10 +61,10 @@ class RedshiftExtract:
             t.schemaname    -- 0
             ,t.tablename    -- 1
             ,t.column       -- 2
-            ,case when t.notnull then 'false' 
-              when not t.notnull then 'true' 
-              else null 
-              end         AS is_null     -- 3
+            ,CASE WHEN t.notnull THEN 'false' 
+              WHEN NOT t.notnull THEN 'true' 
+              ELSE null 
+              END           -- 3
             ,t.type         -- 4
             ,t.distkey      -- 5
             ,t.sortkey      -- 6

--- a/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
+++ b/wherehows-etl/src/main/resources/jython/RedshiftExtract.py
@@ -61,8 +61,8 @@ class RedshiftExtract:
             t.schemaname    -- 0
             ,t.tablename    -- 1
             ,t.column       -- 2
-            ,CASE WHEN t.notnull THEN 'false' 
-              WHEN NOT t.notnull THEN 'true' 
+            ,CASE WHEN t.notnull THEN false 
+              WHEN NOT t.notnull THEN true 
               ELSE null 
               END           -- 3
             ,t.type         -- 4

--- a/wherehows-etl/src/main/resources/jython/RedshiftLoad.py
+++ b/wherehows-etl/src/main/resources/jython/RedshiftLoad.py
@@ -154,7 +154,7 @@ class RedshiftLoad:
         delete from dict_field_detail where field_id in (select field_id from t_deleted_fields);
 
         -- update the old record if some thing changed
-        update dict_field_detail t join
+        update ignore dict_field_detail t join
         (
           select x.field_id, s.*
           from stg_dict_field_detail s


### PR DESCRIPTION
Instead of changing the whole UI from Null? to Not_null? I changed the extract query. 

about the `ignore` statement: I don't want to get too deep into the MySQL since we're moving off of it, but I needed to do this to make it work. Since we moved some fields around (changed the sort key of id in caterers/orders/etc by deleting it and recreating it at the end of the table), the update statement has to do a switcheroo on a field that is part of its unique constraint. This causes it to end as soon as it hits the first violation, even though it would be remedied later on. Putting it in a transaction didn't work, but the ignore clause did. It ignores all errors until the end. 